### PR TITLE
Add service worker caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-XCR-Bon
+## XCR-Bon
+
+This project now includes a basic service worker that caches core assets for
+offline usage. When the application is first loaded the service worker caches
+`index.html`, `manifest.json`, icons and other important files. Subsequent
+visits will serve these files from cache when available.
+
+No additional setup is required; the service worker registers automatically on
+page load.

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,7 +1,62 @@
+const CACHE_NAME = 'xcr-cache-v1';
+const ASSETS_TO_CACHE = [
+  '/',
+  '/index.html',
+  '/manifest.json',
+  '/vite.svg',
+  '/icons/icon-192x192.png',
+  '/icons/icon-512x512.png',
+];
+
 self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS_TO_CACHE)),
+  );
   self.skipWaiting();
 });
 
 self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) =>
+      Promise.all(
+        cacheNames
+          .filter((name) => name !== CACHE_NAME)
+          .map((name) => caches.delete(name)),
+      ),
+    ),
+  );
   clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cachedResponse) => {
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      return fetch(event.request)
+        .then((response) => {
+          if (
+            !response ||
+            response.status !== 200 ||
+            response.type !== 'basic'
+          ) {
+            return response;
+          }
+
+          const responseToCache = response.clone();
+          caches
+            .open(CACHE_NAME)
+            .then((cache) => cache.put(event.request, responseToCache));
+
+          return response;
+        })
+        .catch(() => caches.match('/index.html'));
+    }),
+  );
 });


### PR DESCRIPTION
## Summary
- cache essential assets in `public/sw.js`
- document new offline caching behaviour

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run test:e2e` *(fails: multiple Playwright tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_685863782b94832aaed5b818b4681c85