### PR TITLE
Add habitation page and unify contact email

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import ContactPage from './pages/ContactPage';
 import AssuranceAutoPage from './pages/AssuranceAutoPage';
 import AssuranceEmprunteurPage from './pages/AssuranceEmprunteurPage';
 import AssuranceSantePage from './pages/AssuranceSantePage';
+import AssuranceHabitationPage from './pages/AssuranceHabitationPage';
 import ProtectionJuridiquePage from './pages/ProtectionJuridiquePage';
 import SolutionsFinancieresPage from './pages/SolutionsFinancieresPage';
 import RCProPage from './pages/RCProPage';
@@ -64,6 +65,10 @@ function App() {
 
             {/* Particuliers */}
             <Route path="/assurance-auto" element={<AssuranceAutoPage />} />
+            <Route
+              path="/particuliers/protection-biens/assurance-habitation"
+              element={<AssuranceHabitationPage />}
+            />
             <Route path="/particuliers/sante" element={<AssuranceSantePage />} />
             <Route
               path="/assurance-emprunteur"

--- a/src/components/forms/AutoInsuranceQuoteForm.tsx
+++ b/src/components/forms/AutoInsuranceQuoteForm.tsx
@@ -286,7 +286,7 @@ const AutoInsuranceQuoteForm = ({ formType, className = '' }: AutoInsuranceQuote
         onSuccess={handleFormSuccess}
         onError={handleFormError}
         emailConfig={{
-          recipient: 'auto@xcr.fr',
+          recipient: 'contact@xcr.fr',
           subject: `[Devis Auto] - ${config.title}`,
           priority: 'high'
         }}

--- a/src/components/forms/ContactForm.tsx
+++ b/src/components/forms/ContactForm.tsx
@@ -35,10 +35,10 @@ const ContactForm: React.FC<ContactFormProps> = ({ className = '' }) => {
   const [isSubmitted, setIsSubmitted] = useState(false);
 
   const services = [
-    { value: 'commercial', label: 'Commercial', email: 'commercial@xcr.fr' },
-    { value: 'gestion', label: 'Gestion', email: 'gestion@xcr.fr' },
-    { value: 'sinistre', label: 'Sinistres', email: 'sinistre@xcr.fr' },
-    { value: 'patrimoine', label: 'Patrimoine', email: 'patrimoine@xcr.fr' },
+    { value: 'commercial', label: 'Commercial', email: 'contact@xcr.fr' },
+    { value: 'gestion', label: 'Gestion', email: 'contact@xcr.fr' },
+    { value: 'sinistre', label: 'Sinistres', email: 'contact@xcr.fr' },
+    { value: 'patrimoine', label: 'Patrimoine', email: 'contact@xcr.fr' },
   ];
 
   // Validation functions
@@ -123,9 +123,7 @@ const ContactForm: React.FC<ContactFormProps> = ({ className = '' }) => {
     setIsSubmitting(true);
 
     try {
-      // Get the selected service email
-      const selectedService = services.find(s => s.value === formData.service);
-      const targetEmail = selectedService?.email || 'contact@xcr.fr';
+      const targetEmail = 'contact@xcr.fr';
 
       // Prepare form data for Netlify
       const netlifyFormData = new FormData();

--- a/src/components/forms/DecennaleLeadForm.tsx
+++ b/src/components/forms/DecennaleLeadForm.tsx
@@ -314,7 +314,7 @@ const DecennaleLeadForm = ({ metier, className = '' }: DecennaleLeadFormProps) =
         onSuccess={handleFormSuccess}
         onError={handleFormError}
         emailConfig={{
-          recipient: 'decennale@xcr.fr',
+          recipient: 'contact@xcr.fr',
           subject: `[Lead Décennale] - ${metier.charAt(0).toUpperCase() + metier.slice(1)}`,
           priority: 'high'
         }}

--- a/src/components/forms/InsuranceForm.tsx
+++ b/src/components/forms/InsuranceForm.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
 import { motion } from 'framer-motion';
-import { Check, Send, User, Mail, Phone, Building2, FileText, Shield, AlertCircle } from 'lucide-react';
+import { Check, Send, User, Mail, Phone, Building2, FileText, Shield, AlertCircle, Home } from 'lucide-react';
 import FormSubmissionHandler from './FormSubmissionHandler';
 
 interface InsuranceFormProps {
-  type: 'auto' | 'decennale' | 'emprunteur' | 'juridique';
+  type: 'auto' | 'decennale' | 'emprunteur' | 'juridique' | 'habitation';
   className?: string;
 }
 
@@ -57,6 +57,12 @@ const InsuranceForm = ({ type, className = '' }: InsuranceFormProps) => {
       subtitle: 'Défendez vos droits en toutes circonstances',
       coveragePlaceholder: 'Précisez vos besoins (particulier/professionnel, domaines de protection...)',
       icon: <Shield className="w-6 h-6" />,
+    },
+    habitation: {
+      title: 'Devis Assurance Habitation',
+      subtitle: 'Protégez efficacement votre logement',
+      coveragePlaceholder: "Description du logement (surface, localisation, valeur des biens...)",
+      icon: <Home className="w-6 h-6" />,
     },
   };
 
@@ -233,7 +239,7 @@ const InsuranceForm = ({ type, className = '' }: InsuranceFormProps) => {
         onSuccess={handleFormSuccess}
         onError={handleFormError}
         emailConfig={{
-          recipient: `${type}@xcr.fr`,
+          recipient: 'contact@xcr.fr',
           subject: `[Devis ${type.charAt(0).toUpperCase() + type.slice(1)}]`,
           priority: 'high'
         }}

--- a/src/data/siteStructure.tsx
+++ b/src/data/siteStructure.tsx
@@ -350,7 +350,7 @@ const navigationPages: SitePageInfo[] = [
     icon: <Shield className="h-5 w-5" />,
     section: 'particuliers',
     category: 'personnes',
-    status: 'coming-soon',
+    status: 'active',
   },
   {
     id: 'assurance-emprunteur',

--- a/src/pages/AssuranceHabitationPage.tsx
+++ b/src/pages/AssuranceHabitationPage.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Helmet } from 'react-helmet-async';
+import InsuranceForm from '../components/forms/InsuranceForm';
+import OfficialLinksSection from '../components/common/OfficialLinksSection';
+
+const AssuranceHabitationPage = () => {
+  return (
+    <>
+      <Helmet>
+        <title>Assurance Habitation | Devis Gratuit en Ligne | XCR Courtier</title>
+        <meta
+          name="description"
+          content="Obtenez votre devis d'assurance habitation gratuitement avec XCR Courtier. Protégez efficacement votre logement et vos biens."/>
+        <link rel="canonical" href="https://xcr-courtier.fr/assurance-habitation" />
+      </Helmet>
+      <section className="py-12">
+        <div className="container mx-auto px-4">
+          <h1 className="text-3xl font-bold mb-6 text-primary-800">Assurance Habitation</h1>
+          <p className="mb-8 text-gray-700">Pour une couverture complète de votre logement et de vos biens, faites confiance à notre expertise.</p>
+          <InsuranceForm type="habitation" />
+        </div>
+      </section>
+      <OfficialLinksSection />
+    </>
+  );
+};
+
+export default AssuranceHabitationPage;

--- a/src/pages/ContactPage.tsx
+++ b/src/pages/ContactPage.tsx
@@ -6,10 +6,10 @@ import ContactForm from '../components/forms/ContactForm';
 
 const ContactPage = () => {
   const services = [
-    { value: 'commercial', label: 'Commercial', email: 'commercial@xcr.fr' },
-    { value: 'gestion', label: 'Gestion', email: 'gestion@xcr.fr' },
-    { value: 'sinistre', label: 'Sinistres', email: 'sinistre@xcr.fr' },
-    { value: 'patrimoine', label: 'Patrimoine', email: 'patrimoine@xcr.fr' },
+    { value: 'commercial', label: 'Commercial', email: 'contact@xcr.fr' },
+    { value: 'gestion', label: 'Gestion', email: 'contact@xcr.fr' },
+    { value: 'sinistre', label: 'Sinistres', email: 'contact@xcr.fr' },
+    { value: 'patrimoine', label: 'Patrimoine', email: 'contact@xcr.fr' },
   ];
 
   return (


### PR DESCRIPTION
## Summary
- route new **AssuranceHabitationPage** and mark it active in site structure
- update insurance forms to include habitation and use contact@xcr.fr for leads
- ensure Contact page/form also sends to contact@xcr.fr
- update decennale, auto and generic insurance forms to use the same recipient

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_685899eaa290832ab3f80190cecbcebc