### PR TITLE
Fix service worker request handling

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -31,8 +31,12 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
 
-  // Only handle GET requests for http(s) schemes
-  if (event.request.method !== 'GET' || !(url.protocol === 'http:' || url.protocol === 'https:')) {
+  // Only handle same-origin GET requests over http(s)
+  if (
+    event.request.method !== 'GET' ||
+    !(url.protocol === 'http:' || url.protocol === 'https:') ||
+    url.origin !== self.location.origin
+  ) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- restrict service worker fetch handler to same-origin HTTP(S) requests

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6858a59f84a8832abe3b9c907aca391a