### PR TITLE
Fix service worker caching errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 ## XCR-Bon
 
-This project now includes a basic service worker that caches core assets for
-offline usage. When the application is first loaded the service worker caches
-`index.html`, `manifest.json`, icons and other important files. Subsequent
-visits will serve these files from cache when available.
+This project includes a basic service worker that caches core assets for
+offline usage. On the first visit the service worker caches `index.html`,
+`manifest.json`, icons and other important files so subsequent visits can serve
+these resources from cache. The service worker is conservative: it only handles
+same‑origin HTTP(S) `GET` requests, preventing errors when browser extensions
+or other schemes are fetched.
 
 No additional setup is required; the service worker registers automatically on
 page load.

--- a/public/sw.js
+++ b/public/sw.js
@@ -31,8 +31,12 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
 
-  // Only handle GET requests for http(s) schemes
-  if (event.request.method !== 'GET' || !(url.protocol === 'http:' || url.protocol === 'https:')) {
+  // Ignore non-HTTP requests and anything not from our origin
+  if (
+    event.request.method !== 'GET' ||
+    !(url.protocol === 'http:' || url.protocol === 'https:') ||
+    url.origin !== self.location.origin
+  ) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- document service worker restrictions
- clarify fetch handler comment

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6858a59f84a8832abe3b9c907aca391a