### PR TITLE
Fix service worker caching issue

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -57,9 +57,14 @@ self.addEventListener('fetch', (event) => {
           }
 
           const responseToCache = response.clone();
-          caches
-            .open(CACHE_NAME)
-            .then((cache) => cache.put(event.request, responseToCache));
+
+          // Avoid caching requests with unsupported schemes (e.g. chrome-extension)
+          const requestUrl = new URL(event.request.url);
+          if (requestUrl.protocol === 'http:' || requestUrl.protocol === 'https:') {
+            caches
+              .open(CACHE_NAME)
+              .then((cache) => cache.put(event.request, responseToCache));
+          }
 
           return response;
         })


### PR DESCRIPTION
## Summary
- avoid caching unsupported schemes in the service worker

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx playwright test` *(fails: 44 tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_6858af18dc84832a845f304a8d075871