### PR TITLE
Add Mutuelle Editique page using Neoliane API

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import CourtierAssuranceEntreprisePage from './pages/metiers/CourtierAssuranceEn
 import ParticuliersHomePage from './pages/particuliers/ParticuliersHomePage';
 import ProfessionnelsHomePage from './pages/professionnels/ProfessionnelsHomePage';
 import EntreprisesHomePage from './pages/entreprises/EntreprisesHomePage';
+import MutuelleEditiquePage from './pages/MutuelleEditiquePage';
 
 // 404 Page Component
 import NotFoundPage from './pages/NotFoundPage';
@@ -70,6 +71,10 @@ function App() {
               element={<AssuranceHabitationPage />}
             />
             <Route path="/particuliers/sante" element={<AssuranceSantePage />} />
+            <Route
+              path="/mutuelle-editique"
+              element={<MutuelleEditiquePage />}
+            />
             <Route
               path="/assurance-emprunteur"
               element={<AssuranceEmprunteurPage />}

--- a/src/components/navigation/SiteNavigation.tsx
+++ b/src/components/navigation/SiteNavigation.tsx
@@ -123,6 +123,13 @@ const SiteNavigation = () => {
       section: 'particuliers',
       category: 'services',
     },
+    {
+      label: 'API Editique',
+      path: '/mutuelle-editique',
+      icon: <FileText className="h-5 w-5" />,
+      section: 'particuliers',
+      category: 'services',
+    },
 
     // PROFESSIONNELS
     // Protection des personnes

--- a/src/pages/MutuelleEditiquePage.tsx
+++ b/src/pages/MutuelleEditiquePage.tsx
@@ -1,0 +1,118 @@
+import React, { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet-async';
+import {
+  neolianeService,
+  Product,
+  ProductDocument,
+} from '../services/neolianeService';
+
+const MutuelleEditiquePage = () => {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+  const [documents, setDocuments] = useState<ProductDocument[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchProducts = async () => {
+      try {
+        const res = await neolianeService.getProducts();
+        setProducts(res);
+      } catch (err: any) {
+        setError(err.message);
+      }
+    };
+    fetchProducts();
+  }, []);
+
+  const handleSelectChange = async (
+    e: React.ChangeEvent<HTMLSelectElement>,
+  ) => {
+    const gammeId = parseInt(e.target.value, 10);
+    const product = products.find((p) => p.gammeId === gammeId) || null;
+    setSelectedProduct(product);
+    setDocuments([]);
+
+    if (product) {
+      setLoading(true);
+      setError(null);
+      try {
+        const docs = await neolianeService.getProductDocuments(gammeId);
+        setDocuments(docs);
+      } catch (err: any) {
+        setError(err.message);
+      } finally {
+        setLoading(false);
+      }
+    }
+  };
+
+  const handleDownload = async (doc: ProductDocument) => {
+    if (selectedProduct) {
+      await neolianeService.downloadDocument(
+        selectedProduct.gammeId,
+        doc.documentId,
+        doc.filename,
+      );
+    }
+  };
+
+  return (
+    <>
+      <Helmet>
+        <title>API Editique | Mutuelle</title>
+      </Helmet>
+
+      <section className="py-12">
+        <div className="container mx-auto max-w-2xl px-4">
+          <h1 className="text-3xl font-bold mb-6">API Editique</h1>
+
+          {error && <p className="text-red-600 mb-4">{error}</p>}
+
+          <div className="mb-6">
+            <label className="block mb-2 font-medium">Produit</label>
+            <select
+              className="border p-2 w-full"
+              onChange={handleSelectChange}
+              value={selectedProduct?.gammeId ?? ''}
+            >
+              <option value="">Sélectionnez un produit</option>
+              {products.map((p) => (
+                <option key={p.gammeId} value={p.gammeId}>
+                  {p.gammeLabel || `Produit ${p.gammeId}`}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {loading && <p>Chargement...</p>}
+
+          {documents.length > 0 && (
+            <div className="space-y-4">
+              <h2 className="text-xl font-semibold mb-4">Documents</h2>
+              {documents.map((doc) => (
+                <div
+                  key={doc.documentId}
+                  className="border p-4 rounded flex justify-between items-center"
+                >
+                  <div>
+                    <p className="font-medium">{doc.filename}</p>
+                    <p className="text-sm text-gray-600">{doc.label}</p>
+                  </div>
+                  <button
+                    onClick={() => handleDownload(doc)}
+                    className="bg-primary-600 text-white px-3 py-1 rounded"
+                  >
+                    Télécharger
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+    </>
+  );
+};
+
+export default MutuelleEditiquePage;


### PR DESCRIPTION
## Summary
- create `MutuelleEditiquePage` for Neoliane Editique API demo
- register the page route in `App`
- link to the page from main navigation

## Testing
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858b1890fa8832a88289743e4e846b2